### PR TITLE
anaml-ui in pod ssl termination

### DIFF
--- a/modules/app-all/README.md
+++ b/modules/app-all/README.md
@@ -666,6 +666,22 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_override_anaml_ui_kubernetes_deployment_container_env"></a> [override\_anaml\_ui\_kubernetes\_deployment\_container\_env](#input\_override\_anaml\_ui\_kubernetes\_deployment\_container\_env)
+
+Description: (Optional) Additional environment values to pass through to the anaml-ui container. This is useful if you want to use SSL and change the default certificate paths using`NGINX_SSL_CERTIFICATE` and `NGINX_SSL_CERTIFICATE_KEY`
+
+Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_override_anaml_ui_kubernetes_secret_ssl"></a> [override\_anaml\_ui\_kubernetes\_secret\_ssl](#input\_override\_anaml\_ui\_kubernetes\_secret\_ssl)
+
+Description: (Optional) The name of the Kubernetes secret cotaining `tls.cert` and `tls.key` if you wish to terminate SSL inside the pod
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_override_anaml_ui_skin"></a> [override\_anaml\_ui\_skin](#input\_override\_anaml\_ui\_skin)
 
 Description: anaml-ui skin override

--- a/modules/app-all/main.tf
+++ b/modules/app-all/main.tf
@@ -129,14 +129,16 @@ module "anaml-ui" {
     join("", [var.https_urls ? "https" : "http", "://", var.hostname, var.ui_base_path == "/" ? "" : var.ui_base_path, "/api"])
   )
 
-  basepath                       = var.ui_base_path
-  container_registry             = var.container_registry
-  hostname                       = var.hostname
-  kubernetes_namespace           = var.kubernetes_namespace_create ? kubernetes_namespace.anaml_namespace[0].metadata.0.name : var.kubernetes_namespace_name
-  kubernetes_node_selector       = var.kubernetes_pod_node_selector_app
-  kubernetes_service_annotations = var.kubernetes_service_annotations_anaml_ui
-  kubernetes_service_type        = var.kubernetes_service_type
-  skin                           = var.override_anaml_ui_skin
+  basepath                            = var.ui_base_path
+  container_registry                  = var.container_registry
+  hostname                            = var.hostname
+  kubernetes_deployment_container_env = var.override_anaml_ui_kubernetes_deployment_container_env
+  kubernetes_namespace                = var.kubernetes_namespace_create ? kubernetes_namespace.anaml_namespace[0].metadata.0.name : var.kubernetes_namespace_name
+  kubernetes_node_selector            = var.kubernetes_pod_node_selector_app
+  kubernetes_secret_ssl               = var.override_anaml_ui_kubernetes_secret_ssl
+  kubernetes_service_annotations      = var.kubernetes_service_annotations_anaml_ui
+  kubernetes_service_type             = var.kubernetes_service_type
+  skin                                = var.override_anaml_ui_skin
 
   docs_url                 = module.anaml-docs.internal_url
   spark_history_server_url = module.spark-server.spark_history_server_internal_url

--- a/modules/app-all/variables.tf
+++ b/modules/app-all/variables.tf
@@ -316,6 +316,18 @@ variable "override_anaml_ui_skin" {
   description = "anaml-ui skin override"
 }
 
+variable "override_anaml_ui_kubernetes_deployment_container_env" {
+  type        = map(string)
+  description = "(Optional) Additional environment values to pass through to the anaml-ui container. This is useful if you want to use SSL and change the default certificate paths using`NGINX_SSL_CERTIFICATE` and `NGINX_SSL_CERTIFICATE_KEY`"
+  default     = null
+}
+
+variable "override_anaml_ui_kubernetes_secret_ssl" {
+  type        = string
+  default     = null
+  description = "(Optional) The name of the Kubernetes secret cotaining `tls.cert` and `tls.key` if you wish to terminate SSL inside the pod"
+}
+
 variable "postgres_host" {
   type        = string
   default     = null

--- a/modules/app-ui/README.md
+++ b/modules/app-ui/README.md
@@ -1,4 +1,32 @@
 <!-- BEGIN_TF_DOCS -->
+# app-ui Terraform module
+
+This module deploys a Kubernetes Deployment and Service running the Anaml frontend UI web application.
+
+## Terminating SSL inside the pod
+By default Anaml UI uses plain HTTP and delegates SSL termination to Kubernetes Ingress.
+
+If you wish to terminate SSL inside the pod, you should:
+
+1) Create a Kubernetes Secret containing the SSL certificate and key in PEM format with the names "tls.crt" for the certificate and "tls.key" for the key, either using Terraform or kubectl. Below is an example using kubectl.
+```
+kubectl create secret generic anaml-ui-ssl-certs \
+  --from-file=tls.crt=./tls.crt \
+  --from-file=tls.key=./tls.key
+```
+2) Specify the secret using the `kubernetes_secret_ssl` anaml-ui Terraform module parameter.
+
+### Notes:
+If you do not wish to use the filenames `tls.crt` and `tls.secret` you can use the `kubernetes_deployment_container_env` anaml-ui Terraform module parameter setting `NGINX_SSL_CERTIFICATE` and `NGINX_SSL_CERTIFICATE_KEY` with the path `/certificates/MY_FILENAME` respectively where MY\_FILENAME is your new name. I.e.
+
+```
+kubernetes_deployment_container_env = {
+  NGINX_SSL_CERTIFICATE: "/certificates/anaml.crt",
+  NGINX_SSL_CERTIFICATE_KEY: "/certificates/anaml.key"
+}
+
+```
+
 ## Requirements
 
 The following requirements are needed by this module:
@@ -87,6 +115,14 @@ Type: `string`
 
 Default: `"/"`
 
+### <a name="input_kubernetes_deployment_container_env"></a> [kubernetes\_deployment\_container\_env](#input\_kubernetes\_deployment\_container\_env)
+
+Description: (Optional) Additional environment values to pass through to the anaml-ui container. This is useful if you want to use SSL and change the default certificate paths using`NGINX_SSL_CERTIFICATE` and `NGINX_SSL_CERTIFICATE_KEY`
+
+Type: `map(string)`
+
+Default: `null`
+
 ### <a name="input_kubernetes_deployment_labels"></a> [kubernetes\_deployment\_labels](#input\_kubernetes\_deployment\_labels)
 
 Description: Additional labels to add to Kubernetes deployment
@@ -132,6 +168,14 @@ Default: `null`
 Description: (Optional) NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/node-selection).
 
 Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_kubernetes_secret_ssl"></a> [kubernetes\_secret\_ssl](#input\_kubernetes\_secret\_ssl)
+
+Description: (Optional) The name of the Kubernetes secret cotaining `tls.cert` and `tls.key` if you wish to terminate SSL inside the pod
+
+Type: `string`
 
 Default: `null`
 

--- a/modules/app-ui/variables.tf
+++ b/modules/app-ui/variables.tf
@@ -36,6 +36,12 @@ variable "kubernetes_namespace" {
   default     = null
 }
 
+variable "kubernetes_deployment_container_env" {
+  type        = map(string)
+  description = "(Optional) Additional environment values to pass through to the anaml-ui container. This is useful if you want to use SSL and change the default certificate paths using`NGINX_SSL_CERTIFICATE` and `NGINX_SSL_CERTIFICATE_KEY`"
+  default     = null
+}
+
 variable "kubernetes_deployment_name" {
   type        = string
   description = "(Optional) Name of the deployment, must be unique. Cannot be updated. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/identifiers#names)"
@@ -87,6 +93,12 @@ variable "kubernetes_node_selector" {
   default     = null
   nullable    = true
   description = "(Optional) NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. For more info see [Kubernetes reference](http://kubernetes.io/docs/user-guide/node-selection)."
+}
+
+variable "kubernetes_secret_ssl" {
+  type        = string
+  default     = null
+  description = "(Optional) The name of the Kubernetes secret cotaining `tls.cert` and `tls.key` if you wish to terminate SSL inside the pod"
 }
 
 variable "skin" {


### PR DESCRIPTION
Update app-ui and app-all to allow passing through SSL certificate details for terminating SSL inside the UI pod