### PR TITLE
Output kubernetes namespace from app_all

### DIFF
--- a/modules/app-all/README.md
+++ b/modules/app-all/README.md
@@ -1194,6 +1194,10 @@ Description: n/a
 
 Description: n/a
 
+### <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace)
+
+Description: The Kubernetes used for deployments
+
 ### <a name="output_kubernetes_service_account"></a> [kubernetes\_service\_account](#output\_kubernetes\_service\_account)
 
 Description: The Kubernetes service account used for deployments

--- a/modules/app-all/outputs.tf
+++ b/modules/app-all/outputs.tf
@@ -1,11 +1,16 @@
 output "anaml_internal_server_url" {
   description = "The anaml-server url to use from within kubernetes"
-  value = module.anaml-server.internal_url
+  value       = module.anaml-server.internal_url
 }
 
 output "kubernetes_service_account" {
   description = "The Kubernetes service account used for deployments"
   value       = var.kubernetes_service_account_name
+}
+
+output "kubernetes_namespace" {
+  description = "The Kubernetes used for deployments"
+  value       = var.kubernetes_namespace_name
 }
 
 output "kubernetes_service_name_anaml_server" {


### PR DESCRIPTION
This is useful for downstream dependencies, i.e. creating service accounts in GCP for workload identity that need the namespace value.